### PR TITLE
Fix issues with isort, flake8 pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     ]
 
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
   - id: isort
     exclude: ^src/ansys/templates/pypkg/


### PR DESCRIPTION
The currently used version of isort suffers from a conflict with newer versions of Poetry: https://github.com/PyCQA/isort/issues/2077

flake8 was moved from Github to Gitlab; the current repo URL is no longer correct.