### PR TITLE
Alter get_variables to return an abstract Mapping.

### DIFF
--- a/src/ansys/engineeringworkflow/api/iworkflow.py
+++ b/src/ansys/engineeringworkflow/api/iworkflow.py
@@ -187,7 +187,15 @@ class IVariableContainer(ABC):
     """An abstract base class for something that can contain variables"""
 
     @abstractmethod
-    def get_variables(self) -> Collection[IVariable]:
+    def get_variables(self) -> Mapping[str, IVariable]:
+        """
+        Get the variables in this container.
+
+        Returns
+        -------
+        A map of the variables in the container. The keys in the map are the short names
+        of the variables (relative to the container's name).
+        """
         ...
 
 


### PR DESCRIPTION
This allows a simpler, more expressive way of getting the variables that are available on a component, as well as asking for a specific variable if you already know which one you want. Implementations that are asking for information on variables over-the-wire can return an object that executes the required queries on-demand.