### PR TITLE
Fix doc-deploy-dev permissions for gh-pages doc pushes

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -136,6 +136,8 @@ jobs:
     if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     needs: [package]
+    permissions:
+      contents: write # Needed to push built docs to gh-pages during dev deploy
     steps:
       - name: "Deploy the latest documentation"
         uses: ansys/actions/doc-deploy-dev@010ddbe522e0a9aed3cbd850b4e226dcfae4ecda # v8.2.30


### PR DESCRIPTION
Add write permissions for doc push.

https://tfs.ansys.com:8443/tfs/ANSYS_Development/Portfolio/_sprints/taskboard/ModelCenter%20-%20Corsair/Portfolio/2025-PI-2/2025-IT-16?workitem=1384731